### PR TITLE
Allow /?-! in tag names

### DIFF
--- a/mote.js
+++ b/mote.js
@@ -118,7 +118,7 @@ Parser.prototype.re = {
   whitespace: /[ \t]*/,
   trailing: /[ \t]*(?:\r?\n|$)/,
   tagtype: /\{|&|#|\^|\/|>|=|!|\?/,
-  allowed: /[\w\$\.]+/,
+  allowed: /(\w|[?!\/.-])*/,
   lines: /(.*)(\r?\n)?/g
 };
 


### PR DESCRIPTION
Same regex of allowed chars as the original library. 